### PR TITLE
PR: from frugalos_dyn to master

### DIFF
--- a/include/erasurecode/alg_sig.h
+++ b/include/erasurecode/alg_sig.h
@@ -25,33 +25,8 @@
 #ifndef _ALG_SIG_H
 #define _ALG_SIG_H
 
-typedef int (*galois_single_multiply_func)(int, int, int);
-typedef void (*galois_uninit_field_func)(int);
-
-struct jerasure_mult_routines {
-  galois_single_multiply_func galois_single_multiply;
-  galois_uninit_field_func galois_uninit_field;
-};
-
-#if defined(__MACOS__) || defined(__MACOSX__) || defined(__OSX__) || defined(__APPLE__)
-#define JERASURE_SONAME "libJerasure.dylib"
-#else
-#define JERASURE_SONAME "libJerasure.so"
-#endif
-
-typedef struct alg_sig_s
-{
-  int gf_w;
-  int sig_len;
-  struct jerasure_mult_routines mult_routines;
-  void *jerasure_sohandle;
-  int *tbl1_l;
-  int *tbl1_r;
-  int *tbl2_l;
-  int *tbl2_r;
-  int *tbl3_l;
-  int *tbl3_r;
-} alg_sig_t;
+struct alg_sig_s;
+typedef struct alg_sig_s alg_sig_t;
 
 alg_sig_t *init_alg_sig(int sig_len, int gf_w);
 void destroy_alg_sig(alg_sig_t* alg_sig_handle);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,7 +36,7 @@ liberasurecode_la_CPPFLAGS = -Werror @GCOV_FLAGS@
 liberasurecode_la_LIBADD = \
 		builtin/null_code/libnullcode.la -lpthread -lm @GCOV_LDFLAGS@ \
 		builtin/xor_codes/libXorcode.la -lpthread -lm @GCOV_LDFLAGS@ \
-		builtin/rs_vand/liberasurecode_rs_vand.la -lpthread -lm @GCOV_LDFLAGS@
+		builtin/rs_vand/libFrugalosErasurecode_rs_vand.la -lpthread -lm @GCOV_LDFLAGS@
 
 # Version format  (C - A).(A).(R) for C:R:A input
 liberasurecode_la_LDFLAGS = -rpath '$(libdir)' -version-info @LIBERASURECODE_VERSION_INFO@

--- a/src/backends/jerasure/jerasure_rs_cauchy.c
+++ b/src/backends/jerasure/jerasure_rs_cauchy.c
@@ -64,7 +64,7 @@ typedef int (*jerasure_make_decoding_bitmatrix_func)
     (int, int, int, int *, int *, int *, int *);
 typedef void (*jerasure_bitmatrix_dotprod_func)
     (gf2_t*, int, int, int *, int *, int,char **, char **, int, int);
-typedef void (*galois_uninit_field_func)(gf2_t*, int);
+typedef int (*galois_uninit_field_func)(gf2_t*, int);
 typedef gf2_t* (*galois_init_empty_func)();
 typedef void (*galois_destroy_func)(gf2_t*);
 

--- a/src/backends/jerasure/jerasure_rs_cauchy.c
+++ b/src/backends/jerasure/jerasure_rs_cauchy.c
@@ -367,7 +367,7 @@ static void * jerasure_rs_cauchy_init(struct ec_backend_args *args,
     }
 
     func_handle.vptr = NULL;
-    func_handle.vptr = dlsym(backend_sohandle, "galois_destroy_func");
+    func_handle.vptr = dlsym(backend_sohandle, "galois_destroy");
     desc->galois_destroy = func_handle.gdestroyp;
     if (NULL == desc->galois_destroy) {
         goto error;

--- a/src/backends/jerasure/jerasure_rs_cauchy.c
+++ b/src/backends/jerasure/jerasure_rs_cauchy.c
@@ -41,9 +41,9 @@
 #define JERASURE_RS_CAUCHY_LIB_VER_STR "2.0"
 #define JERASURE_RS_CAUCHY_LIB_NAME "jerasure_rs_cauchy"
 #if defined(__MACOS__) || defined(__MACOSX__) || defined(__OSX__) || defined(__APPLE__)
-#define JERASURE_RS_CAUCHY_SO_NAME "libJerasure.dylib"
+#define JERASURE_RS_CAUCHY_SO_NAME "libFrugalosJerasure.dylib"
 #else
-#define JERASURE_RS_CAUCHY_SO_NAME "libJerasure.so.2"
+#define JERASURE_RS_CAUCHY_SO_NAME "libFrugalosJerasure.so.2"
 #endif
 
 /* Forward declarations */

--- a/src/backends/jerasure/jerasure_rs_vand.c
+++ b/src/backends/jerasure/jerasure_rs_vand.c
@@ -314,7 +314,7 @@ static void * jerasure_rs_vand_init(struct ec_backend_args *args,
     }
 
     func_handle.vptr = NULL;
-    func_handle.vptr = dlsym(backend_sohandle, "galois_destroy_func");
+    func_handle.vptr = dlsym(backend_sohandle, "galois_destroy");
     desc->galois_destroy = func_handle.gdestroyp;
     if (NULL == desc->galois_destroy) {
         goto error;

--- a/src/backends/jerasure/jerasure_rs_vand.c
+++ b/src/backends/jerasure/jerasure_rs_vand.c
@@ -56,7 +56,7 @@ typedef int (*jerasure_matrix_decode_func)(gf2_t*, int, int, int, int *, int, in
 typedef int (*jerasure_make_decoding_matrix_func)(gf2_t*, int, int, int, int *, int *, int *, int *);
 typedef int * (*jerasure_erasures_to_erased_func)(int, int, int *);
 typedef void (*jerasure_matrix_dotprod_func)(gf2_t*, int, int, int *,int *, int,char **, char **, int);
-typedef void (*galois_uninit_field_func)(gf2_t*, int);
+typedef int (*galois_uninit_field_func)(gf2_t*, int);
 typedef gf2_t* (*galois_init_empty_func)();
 typedef void (*galois_destroy_func)(gf2_t*);
 

--- a/src/backends/jerasure/jerasure_rs_vand.c
+++ b/src/backends/jerasure/jerasure_rs_vand.c
@@ -41,9 +41,9 @@
 #define JERASURE_RS_VAND_LIB_VER_STR "2.0"
 #define JERASURE_RS_VAND_LIB_NAME "jerasure_rs_vand"
 #if defined(__MACOS__) || defined(__MACOSX__) || defined(__OSX__) || defined(__APPLE__)
-#define JERASURE_RS_VAND_SO_NAME "libJerasure.dylib"
+#define JERASURE_RS_VAND_SO_NAME "libFrugalosJerasure.dylib"
 #else
-#define JERASURE_RS_VAND_SO_NAME "libJerasure.so.2"
+#define JERASURE_RS_VAND_SO_NAME "libFrugalosJerasure.so.2"
 #endif
 
 /* Forward declarations */

--- a/src/backends/rs_vand/liberasurecode_rs_vand.c
+++ b/src/backends/rs_vand/liberasurecode_rs_vand.c
@@ -38,9 +38,9 @@
 #define LIBERASURECODE_RS_VAND_LIB_VER_STR "1.0"
 #define LIBERASURECODE_RS_VAND_LIB_NAME "liberasurecode_rs_vand"
 #if defined(__MACOS__) || defined(__MACOSX__) || defined(__OSX__) || defined(__APPLE__)
-#define LIBERASURECODE_RS_VAND_SO_NAME "liberasurecode_rs_vand.dylib"
+#define LIBERASURECODE_RS_VAND_SO_NAME "libFrugalosErasurecode_rs_vand.dylib"
 #else
-#define LIBERASURECODE_RS_VAND_SO_NAME "liberasurecode_rs_vand.so.1"
+#define LIBERASURECODE_RS_VAND_SO_NAME "libFrugalosErasurecode_rs_vand.so.1"
 #endif
 
 /* Forward declarations */

--- a/src/builtin/rs_vand/Makefile.am
+++ b/src/builtin/rs_vand/Makefile.am
@@ -1,10 +1,10 @@
-lib_LTLIBRARIES = liberasurecode_rs_vand.la
+lib_LTLIBRARIES = libFrugalosErasurecode_rs_vand.la
 
 # liberasurecode_rs_vand params
-liberasurecode_rs_vand_la_SOURCES = rs_galois.c liberasurecode_rs_vand.c
-liberasurecode_rs_vand_la_CPPFLAGS = -I$(top_srcdir)/include/rs_vand @GCOV_FLAGS@
+libFrugalosErasurecode_rs_vand_la_SOURCES = rs_galois.c liberasurecode_rs_vand.c
+libFrugalosErasurecode_rs_vand_la_CPPFLAGS = -I$(top_srcdir)/include/rs_vand @GCOV_FLAGS@
 
 # Version format  (C - A).(A).(R) for C:R:A input
-liberasurecode_rs_vand_la_LDFLAGS = @GCOV_LDFLAGS@ -rpath '$(libdir)' -version-info 1:1:0
+libFrugalosErasurecode_rs_vand_la_LDFLAGS = @GCOV_LDFLAGS@ -rpath '$(libdir)' -version-info 1:1:0
 
 MOSTLYCLEANFILES = *.gcda *.gcno *.gcov

--- a/src/utils/chksum/alg_sig.c
+++ b/src/utils/chksum/alg_sig.c
@@ -44,9 +44,9 @@ struct jerasure_mult_routines {
 };
 
 #if defined(__MACOS__) || defined(__MACOSX__) || defined(__OSX__) || defined(__APPLE__)
-#define JERASURE_SONAME "libJerasure.dylib"
+#define JERASURE_SONAME "libFrugalosJerasure.dylib"
 #else
-#define JERASURE_SONAME "libJerasure.so"
+#define JERASURE_SONAME "libFrugalosJerasure.so"
 #endif
 
 struct alg_sig_s

--- a/src/utils/chksum/alg_sig.c
+++ b/src/utils/chksum/alg_sig.c
@@ -32,7 +32,7 @@
 #define GALOIS_UNINIT "galois_uninit_field"
 
 typedef int (*galois_single_multiply_func)(gf2_t*, int, int, int);
-typedef void (*galois_uninit_field_func)(gf2_t*, int);
+typedef int (*galois_uninit_field_func)(gf2_t*, int);
 typedef gf2_t* (*galois_init_empty_func)();
 typedef void (*galois_destroy_func)(gf2_t*);
 
@@ -81,7 +81,7 @@ galois_single_multiply_func get_galois_multi_func(void *handle) {
     return func_handle.fptr;
 }
 
-void stub_galois_uninit_field(gf2_t* g, int w){}
+int stub_galois_uninit_field(gf2_t* g, int w){ return 0; }
 
 galois_uninit_field_func get_galois_uninit_func(void *handle) {
     /*

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,12 +25,12 @@ check_PROGRAMS += libec_slap
 
 rs_galois_test_SOURCES = builtin/rs_vand/rs_galois_test.c
 rs_galois_test_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/rs_vand  @GCOV_FLAGS@
-rs_galois_test_LDFLAGS = @GCOV_LDFLAGS@ -static-libtool-libs $(top_builddir)/src/builtin/rs_vand/liberasurecode_rs_vand.la
+rs_galois_test_LDFLAGS = @GCOV_LDFLAGS@ -static-libtool-libs $(top_builddir)/src/builtin/rs_vand/libFrugalosErasurecode_rs_vand.la
 check_PROGRAMS += rs_galois_test
 
 liberasurecode_rs_vand_test_SOURCES = builtin/rs_vand/liberasurecode_rs_vand_test.c
 liberasurecode_rs_vand_test_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/include/rs_vand  @GCOV_FLAGS@
-liberasurecode_rs_vand_test_LDFLAGS = @GCOV_LDFLAGS@ -static-libtool-libs $(top_builddir)/src/builtin/rs_vand/liberasurecode_rs_vand.la
+liberasurecode_rs_vand_test_LDFLAGS = @GCOV_LDFLAGS@ -static-libtool-libs $(top_builddir)/src/builtin/rs_vand/libFrugalosErasurecode_rs_vand.la
 check_PROGRAMS += liberasurecode_rs_vand_test
 
 MOSTLYCLEANFILES = *.gcda *.gcno *.gcov \


### PR DESCRIPTION
このPRは以下の内容を含む:
1. jerasureのマルチスレッド対応に伴いインタフェイスが変更されているので、利用側であるopenstack_liberasurecodeにおける変更を行った
2. jerasureで生成するライブラリ名をlibJerasureからlibFrugalosJerasureとしたため、追従
3. builtinのRS_VANDに関するライブラリ名もlibFrugalos始まりとしたため、追従